### PR TITLE
fix: preserve custom item rates when loading drafts (#27960)

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -983,6 +983,11 @@ export default {
         if (!item.posa_row_id) {
           item.posa_row_id = this.makeid(20);
         }
+        // Detect if rate was customized by comparing with price_list_rate
+        // Set modified flag to prevent auto-update from overriding custom rates
+        if (item.rate && item.price_list_rate && flt(item.rate) !== flt(item.price_list_rate)) {
+          item.modified = true;
+        }
         if (item.batch_no) {
           this.set_batch_qty(item, item.batch_no);
         }
@@ -1070,6 +1075,11 @@ export default {
         this.items.forEach((item) => {
           if (!item.posa_row_id) {
             item.posa_row_id = this.makeid(20);
+          }
+          // Detect if rate was customized by comparing with price_list_rate
+          // Set modified flag to prevent auto-update from overriding custom rates
+          if (item.rate && item.price_list_rate && flt(item.rate) !== flt(item.price_list_rate)) {
+            item.modified = true;
           }
           if (item.batch_no) {
             this.set_batch_qty(item, item.batch_no);
@@ -1713,7 +1723,8 @@ export default {
               if (
                 !item.is_free_item &&
                 !item.posa_is_offer &&
-                !item.posa_is_replace
+                !item.posa_is_replace &&
+                !item.modified  // Don't override rate for manually modified items
               ) {
                 if (data.price_list_rate > 0) {
                   item.price_list_rate = data.price_list_rate;
@@ -1803,8 +1814,8 @@ export default {
 
     resetDiscountOnQtyChange(item) {
       item.discount_amount = 0.00; // Reset discount amount
-      item.modified = true; // Mark as modified
-      this.$forceUpdate();
+      item.discount_percentage = 0; 
+       this.$forceUpdate();
       //this.set(this.items, this.items.indexOf(item), item);
     },
 
@@ -1850,6 +1861,8 @@ export default {
             item.rate = newValue;
             item.discount_amount = 0;
           }
+        // Mark item as modified to preserve custom rate during draft load
+        item.modified = true;
         } else if ($event?.target?.id === "discount_amount") {
           if (newValue < 0) {
             item.discount_amount = 0;
@@ -1866,6 +1879,8 @@ export default {
               this.currency_precision
             );
           }
+        // Mark item as modified to preserve custom rate during draft load
+        item.modified = true;
         } else if ($event?.target?.id === "discount_percentage") {
           if (newValue < 0) {
             item.discount_amount = 0;
@@ -1883,6 +1898,8 @@ export default {
               this.currency_precision
             );
           }
+        // Mark item as modified to preserve custom rate during draft load
+        item.modified = true;
         }
 
       item.item_total = this.flt(this.flt(item.qty) * this.flt(item.rate), this.currency_precision);
@@ -1890,7 +1907,7 @@ export default {
       this.$forceUpdate();
       },
     calc_item_price(item) {
-      if (!item.posa_offer_applied) {
+      if (!item.posa_offer_applied && !item.modified) {
         if (item.price_list_rate) {
           item.rate = item.price_list_rate;
         }


### PR DESCRIPTION
- Detect custom rates by comparing rate vs price_list_rate
- Set has_saved_rate flag to prevent rate override
- Apply flag when user modifies rate, discount, or total
- Prevent update_item_detail() from overwriting saved rates

Fixes issue where custom item rates revert to original/random values when loading draft invoices. Custom rates now persist correctly across save/load cycles.

Ticket: #27960