### PR TITLE
Fix Credit Note Issued status for store credit returns

### DIFF
--- a/posawesome/posawesome/api/posapp.py
+++ b/posawesome/posawesome/api/posapp.py
@@ -663,18 +663,28 @@ def submit_invoice(invoice, data):
             )
     else:
         invoice_doc.submit()
+        # For store credit (non-cashback) returns, manually update original invoice outstanding
+        # This is needed because ERPNext's native handling has a bug where update_outstanding_for_self
+        # is not considered when calling update_voucher_outstanding for POS invoices
         if (
             invoice_doc.is_return
             and invoice_doc.return_against
             and not is_cashback
         ):
-            return_grand_total = flt(invoice_doc.grand_total)
             original_invoice = frappe.get_doc("Sales Invoice", invoice_doc.return_against)
-            original_grand_total = flt(original_invoice.grand_total)
-            new_outstanding = -(return_grand_total + original_grand_total)
-            original_invoice.db_set("outstanding_amount", new_outstanding)
-            original_invoice.set_status()
+            return_grand_total = flt(invoice_doc.grand_total)
+            original_grand_total = flt(original_invoice.outstanding_amount)
+            new_outstanding = original_grand_total + return_grand_total
 
+            # Update both document object and DB (matching update_voucher_outstanding pattern)
+            original_invoice.outstanding_amount = new_outstanding
+            frappe.db.set_value("Sales Invoice", invoice_doc.return_against, "outstanding_amount", new_outstanding)
+            original_invoice.set_status(update=True)
+
+            # Update return invoice outstanding to 0
+            invoice_doc.outstanding_amount = 0
+            frappe.db.set_value("Sales Invoice", invoice_doc.name, "outstanding_amount", 0)
+            invoice_doc.set_status(update=True)
 
         redeeming_customer_credit(
             invoice_doc, data, is_payment_entry, total_cash, cash_account, invoice_doc.payments


### PR DESCRIPTION
ERPNext has a bug where update_outstanding_for_self is not considered when calling update_voucher_outstanding for POS invoices. This causes the original invoice's outstanding to not be updated for store credit returns, preventing the "Credit Note Issued" status from being set.

Fixed the workaround to match ERPNext's update_voucher_outstanding pattern:
- Update document object before calling set_status
- Use frappe.db.set_value instead of db_set
- Call set_status(update=True) to persist the status
- Use outstanding_amount instead of grand_total for accuracy